### PR TITLE
18_Rails動画教材ページの実装

### DIFF
--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,4 +1,5 @@
 class MoviesController < ApplicationController
   def index
+    @movies = Movie.all
   end
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -9,7 +9,7 @@
         <%= link_to "Rails", "#",  class: "nav-link dropdown-toggle", id: "navbarDropdownMenuLink", role: "button", data: { toggle: "dropdown" }, aria: { haspopup: "true", expanded: "false" } %>
           <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
             <%= link_to "Ruby/Rails", "#",  class: "dropdown-item" %>
-            <%= link_to "動画教材", "/movies",  class: "dropdown-item" %>
+            <%= link_to "動画教材", "/",  class: "dropdown-item" %>
             <%= link_to "AWS講座", "#",  class: "dropdown-item" %>
             <%= link_to "ライブコーディング", "#",  class: "dropdown-item" %>
             <%= link_to "質問集", "#",  class: "dropdown-item" %>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,2 +1,15 @@
-<h1>Movies#index</h1>
-<p>Find me in app/views/movies/index.html.erb</p>
+<div class="row" style="padding-top: 100px;">
+  <% @movies.each do |movie| %>
+    <div class="col-12 col-md-6 col-lg-4">
+      <div class="card border-dark mb-3">
+        <div class="embed-responsive embed-responsive-16by9">
+          <iframe class="embed-responsive-item" src="<%= movie.url %>" allowfullscreen></iframe>
+        </div>
+        <div class="card-body">
+          <a href="#" class="btn btn-secondary btn-block">視聴済みにする</a>
+          <h5 class="card-title" style="padding-top: 10px;"><%= movie.title %></h5>
+        </div>
+      </div>
+    </div>
+  <% end %> 
+</div>


### PR DESCRIPTION
内容
・ナビバーの動画教材ページへのリンクが機能するようにした
・Bootstrapのcardを用いて動画教材ページの一覧表示を実装
・Bootstrapを用いて動画の埋め込みを行なった

参考
・https://getbootstrap.jp/docs/4.2/components/card/
・https://bootstrap-guide.com/utilities/embed