### PR TITLE
19_Rails動画教材ページネーションの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,3 +37,4 @@ gem 'rails-i18n'
 gem 'devise-i18n'
 
 gem 'devise-bootstrap-views'
+gem 'kaminari'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -265,6 +265,7 @@ DEPENDENCIES
   devise-bootstrap-views
   devise-i18n
   jbuilder (~> 2.7)
+  kaminari
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
   pry-byebug

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -23,3 +23,7 @@ body {
   max-width: 576px;
   padding: 2rem;
 }
+
+.pagination {
+  justify-content: center;
+}

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,5 +1,7 @@
 class MoviesController < ApplicationController
+  PER = 24
+
   def index
-    @movies = Movie.all
+    @movies = Movie.page(params[:page]).per(PER)
   end
 end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,5 +1,5 @@
 class MoviesController < ApplicationController
-  PER = 24
+  PER = 18
 
   def index
     @movies = Movie.page(params[:page]).per(PER)

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,3 @@
+<li class='page-item disabled'>
+  <%= link_to raw(t 'views.pagination.truncate'), '#', class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,9 @@
+<% if page.current? %>
+  <li class="page-item active">
+    <%= content_tag :a, page, data: { remote: remote }, rel: page.rel, class: 'page-link' %>
+  </li>
+<% else %>
+  <li class="page-item">
+    <%= link_to page, url, remote: remote, rel: page.rel, class: 'page-link' %>
+  </li>
+<% end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,17 @@
+<%= paginator.render do %>
+  <nav>
+    <ul class="pagination">
+      <%= first_page_tag unless current_page.first? %>
+      <%= prev_page_tag unless current_page.first? %>
+      <% each_page do |page| %>
+        <% if page.left_outer? || page.right_outer? || page.inside_window? %>
+          <%= page_tag page %>
+        <% elsif !page.was_truncated? -%>
+          <%= gap_tag %>
+        <% end %>
+      <% end %>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    </ul>
+  </nav>
+<% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -12,5 +12,5 @@
       </div>
     </div>
   <% end %> 
-  <%= paginate @movies %>
 </div>
+<%= paginate @movies %>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -12,4 +12,5 @@
       </div>
     </div>
   <% end %> 
+  <%= paginate @movies %>
 </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -221,3 +221,10 @@ ja:
       long: "%Y/%m/%d %H:%M"
       short: "%m/%d %H:%M"
     pm: 午後
+  views:
+    pagination:
+      first: "&laquo; 最初"
+      last: "最後 &raquo;"
+      previous: "&lsaquo; 前"
+      next: "次 &rsaquo;"
+      truncate: "..."


### PR DESCRIPTION
- gem 'kaminari' 追加
- 'kaminari'にBootstrapを適用
- ページネーションの日本語化、１ページあたりの動画数を18本に設定
<br>

**動作確認**
`rails s`にてページが分割され、動画教材が表示されること確認
ページネーションのボタンを押下し、ページ遷移可能確認
<br>

**参考資料**
- [gem(Kaminari)でページネーション機能を追加してBootstrapを適用する。](https://qiita.com/residenti/items/1ae1e5ceb59c0729c0b9)
- [ページネーションを実装して自分好みにデザインを変える](https://qiita.com/rio_threehouse/items/313824b90a31268b0074)
- [kaminariのページネーションを中央寄せにする](https://qiita.com/tsubasa_upset/items/0274d81f39d7afd08f75)