### PR TITLE
17_AWSテキスト教材詳細ページの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,3 +38,6 @@ gem 'devise-i18n'
 
 gem 'devise-bootstrap-views'
 gem 'kaminari'
+
+gem 'redcarpet', '~> 2.3.0'
+gem 'coderay'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -203,6 +203,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redcarpet (2.3.0)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -261,6 +262,7 @@ DEPENDENCIES
   activeadmin
   bootsnap (>= 1.4.2)
   byebug
+  coderay
   devise
   devise-bootstrap-views
   devise-i18n
@@ -274,6 +276,7 @@ DEPENDENCIES
   puma (~> 4.1)
   rails (~> 6.0.3)
   rails-i18n
+  redcarpet (~> 2.3.0)
   sass-rails (>= 6)
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/controllers/aws_texts_controller.rb
+++ b/app/controllers/aws_texts_controller.rb
@@ -2,4 +2,8 @@ class AwsTextsController < ApplicationController
   def index
     @aws_texts = AwsText.all
   end
+
+  def show
+    aws_text = AwsText.find(params[:id])
+  end
 end

--- a/app/controllers/aws_texts_controller.rb
+++ b/app/controllers/aws_texts_controller.rb
@@ -4,6 +4,6 @@ class AwsTextsController < ApplicationController
   end
 
   def show
-    aws_text = AwsText.find(params[:id])
+    @aws_text = AwsText.find(params[:id])
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,48 @@
 module ApplicationHelper
+  require "redcarpet"
+  require "coderay"
+
+  class HTMLwithCoderay < Redcarpet::Render::HTML
+    def block_code(code, language)
+      language = language.split(":")[0] if language.present?
+
+      case language.to_s
+      when "rb"
+        lang = :ruby
+      when "yml"
+        lang = :yaml
+      when "css"
+        lang = :css
+      when "html"
+        lang = :html
+      when ""
+        lang = :md
+      else
+        lang = language
+      end
+
+      CodeRay.scan(code, lang).div
+    end
+  end
+
+  def markdown(text)
+    html_render = HTMLwithCoderay.new(
+      filter_html: true,
+      hard_wrap: true,
+      link_attributes: { rel: "nofollow", target: "_blank" },
+    )
+    options = {
+      autolink: true,
+      space_after_headers: true,
+      no_intra_emphasis: true,
+      fenced_code_blocks: true,
+      tables: true,
+      hard_wrap: true,
+      xhtml: true,
+      lax_html_blocks: true,
+      strikethrough: true,
+    }
+    markdown = Redcarpet::Markdown.new(html_render, options)
+    markdown.render(text)
+  end
 end

--- a/app/views/aws_texts/index.html.erb
+++ b/app/views/aws_texts/index.html.erb
@@ -6,8 +6,9 @@
       <thead class="text-white bg-primary">
         <tr>
         <th>No</th>
-        <th>内容</th>
+        <th><%= "内容" %></th>
         </tr>
+        <th><%= link_to "詳細", aws_texts_path %></th>
       </thead>
       <tbody>
         <% @aws_texts.each.with_index(1) do |aws_text,i| %>

--- a/app/views/aws_texts/index.html.erb
+++ b/app/views/aws_texts/index.html.erb
@@ -8,13 +8,12 @@
         <th>No</th>
         <th><%= "内容" %></th>
         </tr>
-        <th><%= link_to "詳細", aws_texts_path %></th>
       </thead>
       <tbody>
         <% @aws_texts.each.with_index(1) do |aws_text,i| %>
           <tr>
-          <th><%= i%></th>
-          <th class="text-primary"><%= aws_text.title %></th>
+          <th><%= i %></th>
+          <th><%= link_to aws_text.title, aws_text %></th>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/aws_texts/show.html.erb
+++ b/app/views/aws_texts/show.html.erb
@@ -1,8 +1,10 @@
+<h1>詳細</h1>
+<p>タイトル <%= @aws_text.title %></p>
+
 <%
   text =<<~TEXT
-    # 大見出し
-    ## 中見出し
-    ### 小見出し
+    ### 内容 
   TEXT
  %>
+ 
 <%= markdown(text).html_safe %>

--- a/app/views/aws_texts/show.html.erb
+++ b/app/views/aws_texts/show.html.erb
@@ -7,4 +7,4 @@
   TEXT
  %>
  
-<%= markdown(text).html_safe %>
+<%= markdown(@aws_text.content).html_safe %>

--- a/app/views/aws_texts/show.html.erb
+++ b/app/views/aws_texts/show.html.erb
@@ -1,0 +1,8 @@
+<%
+  text =<<~TEXT
+    # 大見出し
+    ## 中見出し
+    ### 小見出し
+  TEXT
+ %>
+<%= markdown(text).html_safe %>

--- a/app/views/aws_texts/show.html.erb
+++ b/app/views/aws_texts/show.html.erb
@@ -1,10 +1,4 @@
 <h1>詳細</h1>
 <p>タイトル <%= @aws_text.title %></p>
 
-<%
-  text =<<~TEXT
-    ### 内容 
-  TEXT
- %>
- 
 <%= markdown(@aws_text.content).html_safe %>


### PR DESCRIPTION
(問題点ご指摘依頼）
【取り組んだ内容】
・一覧ページの「内容」から詳細ページに移動できるように設定
→一覧ページに詳細ページへのリンクを作成
・詳細ページを作成
→ルーティング・コントローラを設定
・Markdownに対応した表示ができるように設定
→gemをインストール
【参考資料】
逆転教材
「resources を使ったCRUD処理の実装」、「RailsアプリへのMarkdownの導入」